### PR TITLE
Bump SPA package to 0.6.0

### DIFF
--- a/examples/next/yarn.lock
+++ b/examples/next/yarn.lock
@@ -6,18 +6,18 @@
   version "0.0.0"
   uid ""
 
-"@fingerprintjs/fingerprintjs-pro-spa@^0.4.0":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro-spa/-/fingerprintjs-pro-spa-0.4.1.tgz#b9324ef94c0890b05c82501858c26c32fa0c8e14"
-  integrity sha512-xAW2eDRbqjdnsZ4AxhH+p4pa9QYQ7gUiGWGJJE0jBd+Q6dEdCFtfjE3tAx8KsYIN/I3+zuHHnV7XBOub/0MAPA==
+"@fingerprintjs/fingerprintjs-pro-spa@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro-spa/-/fingerprintjs-pro-spa-0.6.0.tgz#991f9d46143253e28b2877effa320ed0374f8ae4"
+  integrity sha512-cMww0FNh41H3eyL6pusXN65fNOz6U+mumQ5KHm2wx66iFvPWHLXMUufPWsUaXYE7EWHseuznuUcO+VSVN+ubyQ==
   dependencies:
-    "@fingerprintjs/fingerprintjs-pro" "^3.6.2"
+    "@fingerprintjs/fingerprintjs-pro" "^3.8.0"
     tslib "^2.2.0"
 
-"@fingerprintjs/fingerprintjs-pro@^3.6.2":
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro/-/fingerprintjs-pro-3.6.3.tgz#38c74da6222ff789756290dec8246452984340ad"
-  integrity sha512-mfWIG+dKjcNu2/ahOKUwV0KekDkmvcZ5MWwQOiic3QmTzAIqLacYtJfI6B8qKkj3AOsDxM3zNIHMsZXjMhb1XQ==
+"@fingerprintjs/fingerprintjs-pro@^3.8.0":
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro/-/fingerprintjs-pro-3.8.0.tgz#586bef92c6bca912c03b38ab23437c12628d871c"
+  integrity sha512-ZSrpmkzIWk3UfArj/1QzTvFY30Q2sk2YbTaE9GvVvG5HZtHOEzv58FlClXpdmTl4Bkbzki6Fofc7t7R+P9ZDLg==
   dependencies:
     tslib "^2.0.1"
 
@@ -126,6 +126,11 @@ csstype@^3.0.2:
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.11.tgz#d66700c5eacfac1940deb4e3ee5642792d85cd33"
   integrity sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==
+
+fast-deep-equal@3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"

--- a/examples/preact/yarn.lock
+++ b/examples/preact/yarn.lock
@@ -1003,22 +1003,21 @@
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
 "@fingerprintjs/fingerprintjs-pro-react@link:../..":
-  version "1.3.1"
-  dependencies:
-    "@fingerprintjs/fingerprintjs-pro-spa" "^0.4.0"
+  version "0.0.0"
+  uid ""
 
-"@fingerprintjs/fingerprintjs-pro-spa@^0.4.0":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro-spa/-/fingerprintjs-pro-spa-0.4.1.tgz#b9324ef94c0890b05c82501858c26c32fa0c8e14"
-  integrity sha512-xAW2eDRbqjdnsZ4AxhH+p4pa9QYQ7gUiGWGJJE0jBd+Q6dEdCFtfjE3tAx8KsYIN/I3+zuHHnV7XBOub/0MAPA==
+"@fingerprintjs/fingerprintjs-pro-spa@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro-spa/-/fingerprintjs-pro-spa-0.6.0.tgz#991f9d46143253e28b2877effa320ed0374f8ae4"
+  integrity sha512-cMww0FNh41H3eyL6pusXN65fNOz6U+mumQ5KHm2wx66iFvPWHLXMUufPWsUaXYE7EWHseuznuUcO+VSVN+ubyQ==
   dependencies:
-    "@fingerprintjs/fingerprintjs-pro" "^3.6.2"
+    "@fingerprintjs/fingerprintjs-pro" "^3.8.0"
     tslib "^2.2.0"
 
-"@fingerprintjs/fingerprintjs-pro@^3.6.2":
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro/-/fingerprintjs-pro-3.6.3.tgz#38c74da6222ff789756290dec8246452984340ad"
-  integrity sha512-mfWIG+dKjcNu2/ahOKUwV0KekDkmvcZ5MWwQOiic3QmTzAIqLacYtJfI6B8qKkj3AOsDxM3zNIHMsZXjMhb1XQ==
+"@fingerprintjs/fingerprintjs-pro@^3.8.0":
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro/-/fingerprintjs-pro-3.8.0.tgz#586bef92c6bca912c03b38ab23437c12628d871c"
+  integrity sha512-ZSrpmkzIWk3UfArj/1QzTvFY30Q2sk2YbTaE9GvVvG5HZtHOEzv58FlClXpdmTl4Bkbzki6Fofc7t7R+P9ZDLg==
   dependencies:
     tslib "^2.0.1"
 
@@ -4898,7 +4897,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
   integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
 
-fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
+fast-deep-equal@3.1.3, fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==

--- a/examples/spa/yarn.lock
+++ b/examples/spa/yarn.lock
@@ -1161,20 +1161,18 @@
     strip-json-comments "^3.1.1"
 
 "@fingerprintjs/fingerprintjs-pro-react@link:../..":
-  version "2.0.0"
-  dependencies:
-    "@fingerprintjs/fingerprintjs-pro-spa" "^0.5.0"
-    fast-deep-equal "3.1.3"
+  version "0.0.0"
+  uid ""
 
-"@fingerprintjs/fingerprintjs-pro-spa@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro-spa/-/fingerprintjs-pro-spa-0.5.0.tgz#7ba74a3dab7db3c8ba06334caf9499b0cbf79263"
-  integrity sha512-AUy8pJoDMivmwqv6VdBxw7p9md3MmBwSlA3GccUybu3jQWGMDa4UB/XaPfRePIO7riD1bNp9bhZXNqo+b6O7ag==
+"@fingerprintjs/fingerprintjs-pro-spa@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro-spa/-/fingerprintjs-pro-spa-0.6.0.tgz#991f9d46143253e28b2877effa320ed0374f8ae4"
+  integrity sha512-cMww0FNh41H3eyL6pusXN65fNOz6U+mumQ5KHm2wx66iFvPWHLXMUufPWsUaXYE7EWHseuznuUcO+VSVN+ubyQ==
   dependencies:
-    "@fingerprintjs/fingerprintjs-pro" "^3.7.1"
+    "@fingerprintjs/fingerprintjs-pro" "^3.8.0"
     tslib "^2.2.0"
 
-"@fingerprintjs/fingerprintjs-pro@^3.7.1":
+"@fingerprintjs/fingerprintjs-pro@^3.8.0":
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro/-/fingerprintjs-pro-3.8.0.tgz#586bef92c6bca912c03b38ab23437c12628d871c"
   integrity sha512-ZSrpmkzIWk3UfArj/1QzTvFY30Q2sk2YbTaE9GvVvG5HZtHOEzv58FlClXpdmTl4Bkbzki6Fofc7t7R+P9ZDLg==
@@ -5872,7 +5870,7 @@ lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-loose-envify@^1.4.0:
+loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -7188,6 +7186,7 @@ react-dev-utils@^12.0.1:
 
 "react-dom@link:../../node_modules/react-dom":
   version "0.0.0"
+  uid ""
 
 react-error-boundary@^3.1.0:
   version "3.1.4"
@@ -7293,6 +7292,7 @@ react-scripts@5.0.1:
 
 "react@link:../../node_modules/react":
   version "0.0.0"
+  uid ""
 
 readable-stream@^2.0.1:
   version "2.3.7"
@@ -7566,6 +7566,13 @@ saxes@^5.0.1:
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
   dependencies:
     xmlchars "^2.2.0"
+
+scheduler@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
+  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
+  dependencies:
+    loose-envify "^1.1.0"
 
 schema-utils@2.7.0:
   version "2.7.0"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "homepage": "https://github.com/fingerprintjs/fingerprintjs-pro-react#readme",
   "dependencies": {
-    "@fingerprintjs/fingerprintjs-pro-spa": "^0.5.0",
+    "@fingerprintjs/fingerprintjs-pro-spa": "^0.6.0",
     "fast-deep-equal": "3.1.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -647,18 +647,18 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@fingerprintjs/fingerprintjs-pro-spa@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro-spa/-/fingerprintjs-pro-spa-0.5.0.tgz#7ba74a3dab7db3c8ba06334caf9499b0cbf79263"
-  integrity sha512-AUy8pJoDMivmwqv6VdBxw7p9md3MmBwSlA3GccUybu3jQWGMDa4UB/XaPfRePIO7riD1bNp9bhZXNqo+b6O7ag==
+"@fingerprintjs/fingerprintjs-pro-spa@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro-spa/-/fingerprintjs-pro-spa-0.6.0.tgz#991f9d46143253e28b2877effa320ed0374f8ae4"
+  integrity sha512-cMww0FNh41H3eyL6pusXN65fNOz6U+mumQ5KHm2wx66iFvPWHLXMUufPWsUaXYE7EWHseuznuUcO+VSVN+ubyQ==
   dependencies:
-    "@fingerprintjs/fingerprintjs-pro" "^3.7.1"
+    "@fingerprintjs/fingerprintjs-pro" "^3.8.0"
     tslib "^2.2.0"
 
-"@fingerprintjs/fingerprintjs-pro@^3.7.1":
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro/-/fingerprintjs-pro-3.7.1.tgz#ece7679d2bdb05bce9fc6c1a64f7aa8705f1b908"
-  integrity sha512-06t3lqFwq0fpt5MFfppoNfZgd/jhnfv15lklVtaGhqkKyNpB81kwCM9iIqku7dhaEUFXlGZg5VcoA8zjkC483A==
+"@fingerprintjs/fingerprintjs-pro@^3.8.0":
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro/-/fingerprintjs-pro-3.8.0.tgz#586bef92c6bca912c03b38ab23437c12628d871c"
+  integrity sha512-ZSrpmkzIWk3UfArj/1QzTvFY30Q2sk2YbTaE9GvVvG5HZtHOEzv58FlClXpdmTl4Bkbzki6Fofc7t7R+P9ZDLg==
   dependencies:
     tslib "^2.0.1"
 


### PR DESCRIPTION
Updates JS Agent to 3.8.0 to support fallbacks for `scriptUrlPattern`, `endpoint` and `tlsEndpoint`