### PR TITLE
docs: document caching default change INTER-1988

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### ⚠ BREAKING CHANGES
 
 * The SDK api has changed to match changes introduced in V4 version of the agent.
+* The default caching strategy has changed from `sessionStorage` caching to **no caching by default**, aligned with the underlying [JavaScript agent v4 default](https://docs.fingerprint.com/reference/js-agent-v4-start-function#cache).
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ To get your API key and get started, see the [Fingerprint Quick Start Guide](htt
 - Set `apiKey` to your Fingerprint [Public API Key](https://dashboard.fingerprint.com/api-keys).
 - Set `region` if you have chosen a non-global [region](https://docs.fingerprint.com/docs/regions) during registration.
 - Set `endpoint` if you are using [one of our proxy integrations to increase accuracy](https://docs.fingerprint.com/docs/protecting-the-javascript-agent-from-adblockers) and effectiveness of visitor identification.
-- You can use all the [start options](https://docs.fingerprint.com/reference/js-agent-v4-start-function#start-options) available in the JavaScript agent `load` function.
+- You can use all the [start options](https://docs.fingerprint.com/reference/js-agent-v4-start-function#start-options) available in the JavaScript agent `start()` function.
+- Caching is disabled by default. To enable caching, pass the JavaScript agent [`cache` start option](https://docs.fingerprint.com/reference/js-agent-v4-start-function#cache).
 
 ```jsx
 // src/index.js
@@ -95,6 +96,7 @@ const root = ReactDOM.createRoot(document.getElementById('app'))
 root.render(
   <FingerprintProvider
     apiKey='your-public-api-key'
+    cache={{ storage: 'sessionStorage', duration: 3600 }}
   >
     <App />
   </FingerprintProvider>


### PR DESCRIPTION
- Document the breaking change: default caching strategy changed from `sessionStorage` to **no caching** (aligned with JS agent v4 default)
- Add README guidance on how to enable caching with the `cache` start option
- Add example showing `cache={{ storage: 'sessionStorage', duration: 3600 }}` for users wanting to preserve previous behavior