### PR TITLE
docs: update Fingerprint branding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,7 @@
 
 ### Features
 
-* update @fingerprintjs/fingerprintjs-pro-spa to 1.2.0, add FingerprintJSPro export ([8066afe](https://github.com/fingerprintjs/fingerprintjs-pro-react/commit/8066afe0a285f1b8ace4c1debe74860034752655))
+* update @fingerprintjs/fingerprintjs-pro-spa to 1.2.0, add agent export ([8066afe](https://github.com/fingerprintjs/fingerprintjs-pro-react/commit/8066afe0a285f1b8ace4c1debe74860034752655))
 
 ## [2.5.1](https://github.com/fingerprintjs/fingerprintjs-pro-react/compare/v2.5.0...v2.5.1) (2023-09-14)
 
@@ -274,7 +274,7 @@
 
 * **deps:** bump terser from 4.8.0 to 4.8.1 in /examples/preact ([6947ad5](https://github.com/fingerprintjs/fingerprintjs-pro-react/commit/6947ad553a39107736affb43ad1e0bbfce5c09a9))
 * **deps:** bump terser from 5.13.1 to 5.14.2 in /examples/spa ([e94c1ce](https://github.com/fingerprintjs/fingerprintjs-pro-react/commit/e94c1ce1106795f88390545f1a76a979e77c2f20))
-* **deps:** update FingerprintJS Pro SPA to 0.5.0 ([e4f4039](https://github.com/fingerprintjs/fingerprintjs-pro-react/commit/e4f4039ef0e023003ee03f5dbe67b3e593f50a42))
+* **deps:** update SPA package to 0.5.0 ([e4f4039](https://github.com/fingerprintjs/fingerprintjs-pro-react/commit/e4f4039ef0e023003ee03f5dbe67b3e593f50a42))
 
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Fingerprint is a device intelligence platform offering industry-leading accuracy
 - For Typescript users: Typescript 4.8 or higher
 
 > [!NOTE]
-> This package assumes you have a Fingerprint subscription or trial, it is not compatible with the [source-available FingerprintJS](https://github.com/fingerprintjs/fingerprintjs). See our documentation to learn more about the [differences between Fingerprint and FingerprintJS](https://fingerprint.com/github/).
+> This package assumes you have a Fingerprint subscription or trial, it is not compatible with the [open-source FingerprintJS](https://github.com/fingerprintjs/fingerprintjs). See our documentation to learn more about the [differences between Fingerprint and the open-source FingerprintJS](https://fingerprint.com/github/).
 
 ## Installation
 
@@ -84,10 +84,7 @@ To get your API key and get started, see the [Fingerprint Quick Start Guide](htt
 // src/index.js
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import {
-  FingerprintProvider,
-  FingerprintJSPro,
-} from '@fingerprint/react'
+import { FingerprintProvider } from '@fingerprint/react'
 import App from './App'
 
 const root = ReactDOM.createRoot(document.getElementById('app'))
@@ -218,7 +215,7 @@ See the full [generated API reference](https://fingerprintjs.github.io/react/).
 
 ## Support and feedback
 
-To ask questions or provide feedback, use [Issues](https://github.com/fingerprintjs/react/issues). If you need private support, please email us at `oss-support@fingerprint.com`. If you'd like to have a similar React wrapper for the [source-availalbe FingerprintJS](https://github.com/fingerprintjs/fingerprintjs), consider creating an issue in the main [FingerprintJS repository](https://github.com/fingerprintjs/fingerprintjs/issues).
+To ask questions or provide feedback, use [Issues](https://github.com/fingerprintjs/react/issues). If you need private support, please email us at `oss-support@fingerprint.com`.
 
 ## License
 

--- a/examples/create-react-app/README.md
+++ b/examples/create-react-app/README.md
@@ -9,7 +9,7 @@ In order to try out this example:
 To get the API key:
 
 - Go to Fingerprint Dashboard > [API Keys](https://dashboard.fingerprint.com/api-keys) and find it there.
-- If you don't have a Fingerprint Pro account, [sign up for free](https://dashboard.fingerprint.com/signup/).
+- If you don't have a Fingerprint account, [sign up for free](https://dashboard.fingerprint.com/signup/).
 
 ### Installing dependencies
 

--- a/examples/next-appDir/README.md
+++ b/examples/next-appDir/README.md
@@ -1,5 +1,5 @@
-This example demonstrates the usage of Fingerprint Pro inside Next 14's `app` directory approach.\
-Note how you can use Fingerprint Pro inside a React Server Component without issues as it is correctly executed in the browser only.
+This example demonstrates the usage of Fingerprint inside Next 14's `app` directory approach.\
+Note how you can use Fingerprint inside a React Server Component without issues as it is correctly executed in the browser only.
 See [../next](../next/README.md) for an example using the classic `pages` approach.
 
 ## Setting up
@@ -13,7 +13,7 @@ In order to try out this example:
 To get the API key:
 
 - Go to Fingerprint Dashboard > [API Keys](https://dashboard.fingerprint.com/api-keys) and find it there.
-- If you don't have a Fingerprint Pro account, [sign up for free](https://dashboard.fingerprint.com/signup/).
+- If you don't have a Fingerprint account, [sign up for free](https://dashboard.fingerprint.com/signup/).
 
 ### Installing dependencies
 

--- a/examples/next-appDir/app/HomePage.tsx
+++ b/examples/next-appDir/app/HomePage.tsx
@@ -12,16 +12,14 @@ const HomePage = () => {
 
   return (
     <div className={styles.container}>
-      <h1>FingerprintJS Pro NextJS Demo</h1>
+      <h1>Fingerprint React SDK Next.js Demo</h1>
       <div className={styles.testArea}>
-        <div className={styles.description}>
-          Lets load FingerprintJS Pro Agent using react integration and check next things:
-        </div>
+        <div className={styles.description}>Lets load Fingerprint using the React SDK and check the following:</div>
         <ol className={styles.actionPoints}>
-          <li>There is no errors on server</li>
-          <li>There is no errors on client</li>
-          <li>In the field below visitor data was loaded</li>
-          <li>Try controls to test additional params</li>
+          <li>There are no errors on the server</li>
+          <li>There are no errors on the client</li>
+          <li>The visitor data is loaded in the field below</li>
+          <li>Try controls to test additional parameters</li>
         </ol>
         <div className={styles.controls}>
           <button onClick={reloadData} type='button'>

--- a/examples/next-appDir/app/head.tsx
+++ b/examples/next-appDir/app/head.tsx
@@ -1,8 +1,8 @@
 export default function Head() {
   return (
     <>
-      <title>FingerprintJS Pro NextJS Demo</title>
-      <meta name='description' content='Check if fingerprintjs-pro-react integration works with NextJS SSR' />
+      <title>Fingerprint React SDK Next.js Demo</title>
+      <meta name='description' content='Check if the Fingerprint React SDK integration works with Next.js SSR' />
       <link rel='icon' href='/favicon.ico' />
     </>
   )

--- a/examples/next/README.md
+++ b/examples/next/README.md
@@ -1,4 +1,4 @@
-This example demonstrates the usage of Fingerprint Pro inside the Next.js `pages` directory (classic approach). For an example using the `app` directory, see [../next-appDir](../next-appDir/README.md).
+This example demonstrates the usage of Fingerprint inside the Next.js `pages` directory (classic approach). For an example using the `app` directory, see [../next-appDir](../next-appDir/README.md).
 
 ## Setting up
 
@@ -12,7 +12,7 @@ In order to try out this example:
 To get the API key:
 
 - Go to Fingerprint Dashboard > [API Keys](https://dashboard.fingerprint.com/api-keys) and find it there.
-- If you don't have a Fingerprint Pro account, [sign up for free](https://dashboard.fingerprint.com/signup/).
+- If you don't have a Fingerprint account, [sign up for free](https://dashboard.fingerprint.com/signup/).
 
 ### Installing dependencies
 

--- a/examples/next/pages/index.tsx
+++ b/examples/next/pages/index.tsx
@@ -13,21 +13,19 @@ const Home: NextPage = () => {
   return (
     <div className={styles.container}>
       <Head>
-        <title>FingerprintJS Pro NextJS Demo</title>
-        <meta name='description' content='Check if fingerprintjs-pro-react integration works with NextJS SSR' />
+        <title>Fingerprint React SDK Next.js Demo</title>
+        <meta name='description' content='Check if the Fingerprint React SDK integration works with Next.js SSR' />
         <link rel='icon' href='/favicon.ico' />
       </Head>
 
-      <h1>FingerprintJS Pro NextJS Demo</h1>
+      <h1>Fingerprint React SDK Next.js Demo</h1>
       <div className={styles.testArea}>
-        <div className={styles.description}>
-          Lets load FingerprintJS Pro Agent using react integration and check next things:
-        </div>
+        <div className={styles.description}>Lets load Fingerprint using the React SDK and check the following:</div>
         <ol className={styles.actionPoints}>
-          <li>There is no errors on server</li>
-          <li>There is no errors on client</li>
-          <li>In the field below visitor data was loaded</li>
-          <li>Try controls to test additional params</li>
+          <li>There are no errors on the server</li>
+          <li>There are no errors on the client</li>
+          <li>The visitor data is loaded in the field below</li>
+          <li>Try controls to test additional parameters</li>
         </ol>
         <div className={styles.controls}>
           <button onClick={reloadData} type='button'>

--- a/examples/preact/README.md
+++ b/examples/preact/README.md
@@ -10,7 +10,7 @@ In order to try out this example:
 To get the API key:
 
 - Go to Fingerprint Dashboard > [API Keys](https://dashboard.fingerprint.com/api-keys) and find it there.
-- If you don't have a Fingerprint Pro account, [sign up for free](https://dashboard.fingerprint.com/signup/).
+- If you don't have a Fingerprint account, [sign up for free](https://dashboard.fingerprint.com/signup/).
 
 ### Installing dependencies
 

--- a/examples/preact/src/components/app.tsx
+++ b/examples/preact/src/components/app.tsx
@@ -10,16 +10,14 @@ const App: FunctionalComponent = () => {
 
   return (
     <div id='preact_root' className='container'>
-      <h1>FingerprintJS Pro Preact Demo</h1>
+      <h1>Fingerprint React SDK Preact Demo</h1>
       <div className='testArea'>
-        <div className='description'>
-          Lets load FingerprintJS Pro Agent using react integration and check next things:
-        </div>
+        <div className='description'>Lets load Fingerprint using the React SDK and check the following:</div>
         <ol className='actionPoints'>
-          <li>There is no errors on server</li>
-          <li>There is no errors on client</li>
-          <li>In the field below visitor data was loaded</li>
-          <li>Try controls to test additional params</li>
+          <li>There are no errors on the server</li>
+          <li>There are no errors on the client</li>
+          <li>The visitor data is loaded in the field below</li>
+          <li>Try controls to test additional parameters</li>
         </ol>
         <div className='controls'>
           <button onClick={reloadData} type='button'>

--- a/examples/webpack-based/README.md
+++ b/examples/webpack-based/README.md
@@ -1,6 +1,6 @@
-# Fingerprint Pro Webpack Example
+# Fingerprint Webpack Example
 
-This example demonstrates the usage of Fingerprint Pro inside a webpack-based project.
+This example demonstrates the usage of Fingerprint inside a webpack-based project.
 
 ## Setting up
 
@@ -13,7 +13,7 @@ In order to try out this example:
 To get the API key:
 
 - Go to Fingerprint Dashboard > [API Keys](https://dashboard.fingerprint.com/api-keys) and find it there.
-- If you don't have a Fingerprint Pro account, [sign up for free](https://dashboard.fingerprint.com/signup/).
+- If you don't have a Fingerprint account, [sign up for free](https://dashboard.fingerprint.com/signup/).
 
 ### Installing dependencies
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fingerprint/react",
   "version": "3.0.0",
-  "description": "FingerprintJS Pro React SDK",
+  "description": "Fingerprint React SDK",
   "main": "dist/fingerprint-react.js",
   "module": "dist/fingerprint-react.mjs",
   "types": "dist/fingerprint-react.d.ts",
@@ -79,6 +79,7 @@
     "eslint": "8.57.0",
     "eslint-config-next": "14.1.3",
     "eslint-config-preact": "^1.3.0",
+    "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-react": "7.34.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "husky": "^9.0.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       eslint-config-preact:
         specifier: ^1.3.0
         version: 1.3.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@6.19.1(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0)(typescript@5.4.2)
+      eslint-plugin-prettier:
+        specifier: ^5.5.5
+        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.2.5)
       eslint-plugin-react:
         specifier: 7.34.0
         version: 7.34.0(eslint@8.57.0)
@@ -137,7 +140,7 @@ importers:
         version: 6.22.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-scripts:
         specifier: 5.0.1
-        version: 5.0.1(@babel/plugin-syntax-flow@7.24.1(@babel/core@7.24.0))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.0))(@types/babel__core@7.20.5)(@types/webpack@4.41.38)(eslint@9.39.2(jiti@1.21.0))(react@18.2.0)(type-fest@3.13.1)(typescript@5.4.2)
+        version: 5.0.1(@babel/plugin-syntax-flow@7.24.1(@babel/core@7.24.0))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.0))(@types/babel__core@7.20.5)(@types/webpack@4.41.38)(eslint@8.57.0)(react@18.2.0)(type-fest@3.13.1)(typescript@5.4.2)
       typescript:
         specifier: '*'
         version: 5.4.2
@@ -1794,28 +1797,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@14.2.32':
     resolution: {integrity: sha512-tA6sIKShXtSJBTH88i0DRd6I9n3ZTirmwpwAqH5zdJoQF7/wlJXR8DkPmKwYl5mFWhEKr5IIa3LfpMW9RRwKmQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@14.2.32':
     resolution: {integrity: sha512-7S1GY4TdnlGVIdeXXKQdDkfDysoIVFMD0lJuVVMeb3eoVjrknQ0JNN7wFlhCvea0hEk0Sd4D1hedVChDKfV2jw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@14.2.32':
     resolution: {integrity: sha512-OHHC81P4tirVa6Awk6eCQ6RBfWl8HpFsZtfEkMpJ5GjPsJ3nhPe6wKAJUZ/piC8sszUkAgv3fLflgzPStIwfWg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@14.2.32':
     resolution: {integrity: sha512-rORQjXsAFeX6TLYJrCG5yoIDj+NKq31Rqwn8Wpn/bkPNy5rTHvOXkW8mLFonItS7QC6M+1JIIcLe+vOCTOYpvg==}
@@ -1864,6 +1863,10 @@ packages:
 
   '@pkgr/core@0.1.1':
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@pkgr/core@0.2.9':
+    resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
   '@pmmmwh/react-refresh-webpack-plugin@0.5.11':
@@ -1997,67 +2000,56 @@ packages:
     resolution: {integrity: sha512-gTJ/JnnjCMc15uwB10TTATBEhK9meBIY+gXP4s0sHD1zHOaIh4Dmy1X9wup18IiY9tTNk5gJc4yx9ctj/fjrIw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.43.0':
     resolution: {integrity: sha512-ZJ3gZynL1LDSIvRfz0qXtTNs56n5DI2Mq+WACWZ7yGHFUEirHBRt7fyIk0NsCKhmRhn7WAcjgSkSVVxKlPNFFw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.43.0':
     resolution: {integrity: sha512-8FnkipasmOOSSlfucGYEu58U8cxEdhziKjPD2FIa0ONVMxvl/hmONtX/7y4vGjdUhjcTHlKlDhw3H9t98fPvyA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.43.0':
     resolution: {integrity: sha512-KPPyAdlcIZ6S9C3S2cndXDkV0Bb1OSMsX0Eelr2Bay4EsF9yi9u9uzc9RniK3mcUGCLhWY9oLr6er80P5DE6XA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.43.0':
     resolution: {integrity: sha512-HPGDIH0/ZzAZjvtlXj6g+KDQ9ZMHfSP553za7o2Odegb/BEfwJcR0Sw0RLNpQ9nC6Gy8s+3mSS9xjZ0n3rhcYg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.43.0':
     resolution: {integrity: sha512-gEmwbOws4U4GLAJDhhtSPWPXUzDfMRedT3hFMyRAvM9Mrnj+dJIFIeL7otsv2WF3D7GrV0GIewW0y28dOYWkmw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.43.0':
     resolution: {integrity: sha512-XXKvo2e+wFtXZF/9xoWohHg+MuRnvO29TI5Hqe9xwN5uN8NKUYy7tXUG3EZAlfchufNCTHNGjEx7uN78KsBo0g==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.43.0':
     resolution: {integrity: sha512-ruf3hPWhjw6uDFsOAzmbNIvlXFXlBQ4nk57Sec8E8rUxs/AI4HD6xmiiasOOx/3QxS2f5eQMKTAwk7KHwpzr/Q==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.43.0':
     resolution: {integrity: sha512-QmNIAqDiEMEvFV15rsSnjoSmO0+eJLoKRD9EAa9rrYNwO/XRCtOGM3A5A0X+wmG+XRrw9Fxdsw+LnyYiZWWcVw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.43.0':
     resolution: {integrity: sha512-jAHr/S0iiBtFyzjhOkAics/2SrXE092qyqEg96e90L3t9Op8OTzS6+IX0Fy5wCt2+KqeHAkti+eitV0wvblEoQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.43.0':
     resolution: {integrity: sha512-3yATWgdeXyuHtBhrLt98w+5fKurdqvs8B53LaoKD7P7H7FKOONLsBVMNl9ghPQZQuYcceV5CDyPfyfGpMWD9mQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.43.0':
     resolution: {integrity: sha512-wVzXp2qDSCOpcBCT5WRWLmpJRIzv23valvcTwMHEobkjippNf+C3ys/+wf07poPkeNix0paTNemB2XrHr2TnGw==}
@@ -4870,6 +4862,20 @@ packages:
       eslint-config-prettier:
         optional: true
 
+  eslint-plugin-prettier@5.5.5:
+    resolution: {integrity: sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      '@types/eslint': '>=8.0.0'
+      eslint: '>=8.0.0'
+      eslint-config-prettier: '>= 7.0.0 <10.0.0 || >=10.1.0'
+      prettier: '>=3.0.0'
+    peerDependenciesMeta:
+      '@types/eslint':
+        optional: true
+      eslint-config-prettier:
+        optional: true
+
   eslint-plugin-react-hooks@4.6.0:
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
     engines: {node: '>=10'}
@@ -5457,16 +5463,17 @@ packages:
   glob@10.3.10:
     resolution: {integrity: sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
@@ -8133,6 +8140,10 @@ packages:
     resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
     engines: {node: '>=6.0.0'}
 
+  prettier-linter-helpers@1.0.1:
+    resolution: {integrity: sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==}
+    engines: {node: '>=6.0.0'}
+
   prettier@3.2.4:
     resolution: {integrity: sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==}
     engines: {node: '>=14'}
@@ -9248,6 +9259,10 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  synckit@0.11.12:
+    resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+
   synckit@0.8.8:
     resolution: {integrity: sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -9272,10 +9287,12 @@ packages:
   tar@4.4.19:
     resolution: {integrity: sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==}
     engines: {node: '>=4.5'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@6.2.0:
     resolution: {integrity: sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
@@ -12337,11 +12354,11 @@ snapshots:
 
   '@fingerprintjs/eslint-config-dx-team@0.1.0(@types/eslint@9.6.1)(prettier@3.2.5)(typescript@5.4.2)':
     dependencies:
-      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1(eslint@8.57.0)(typescript@5.4.2))(eslint@8.56.0)(typescript@5.4.2)
+      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1(eslint@8.56.0)(typescript@5.4.2))(eslint@8.56.0)(typescript@5.4.2)
       '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@5.4.2)
       eslint: 8.56.0
       eslint-config-prettier: 9.1.0(eslint@8.56.0)
-      eslint-plugin-prettier: 5.1.3(@types/eslint@9.6.1)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.56.0)(prettier@3.2.5)
+      eslint-plugin-prettier: 5.1.3(@types/eslint@9.6.1)(eslint-config-prettier@9.1.0(eslint@8.56.0))(eslint@8.56.0)(prettier@3.2.5)
       prettier: 3.2.5
     transitivePeerDependencies:
       - '@types/eslint'
@@ -12745,6 +12762,8 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.1.1': {}
+
+  '@pkgr/core@0.2.9': {}
 
   '@pmmmwh/react-refresh-webpack-plugin@0.5.11(@types/webpack@4.41.38)(react-refresh@0.11.0)(type-fest@3.13.1)(webpack-dev-server@4.15.1(webpack@5.90.3))(webpack@5.90.3)':
     dependencies:
@@ -13348,15 +13367,15 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2))(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2)':
+  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0)(typescript@5.4.2)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.4.2)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2)
-      '@typescript-eslint/utils': 5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2)
+      '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.0)(typescript@5.4.2)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.4.2)
       debug: 4.4.1
-      eslint: 9.39.2(jiti@1.21.0)
+      eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare-lite: 1.4.0
@@ -13387,7 +13406,7 @@ snapshots:
       - supports-color
     optional: true
 
-  '@typescript-eslint/eslint-plugin@6.19.1(@typescript-eslint/parser@6.19.1(eslint@8.57.0)(typescript@5.4.2))(eslint@8.56.0)(typescript@5.4.2)':
+  '@typescript-eslint/eslint-plugin@6.19.1(@typescript-eslint/parser@6.19.1(eslint@8.56.0)(typescript@5.4.2))(eslint@8.56.0)(typescript@5.4.2)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
       '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@5.4.2)
@@ -13451,14 +13470,6 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/experimental-utils@5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2)':
-    dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2)
-      eslint: 9.39.2(jiti@1.21.0)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   '@typescript-eslint/experimental-utils@5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.9.3)
@@ -13467,13 +13478,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/parser@5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2)':
+  '@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.4.2)
       debug: 4.4.1
-      eslint: 9.39.2(jiti@1.21.0)
+      eslint: 8.57.0
     optionalDependencies:
       typescript: 5.4.2
     transitivePeerDependencies:
@@ -13574,19 +13585,6 @@ snapshots:
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.4.2)
       debug: 4.4.1
       eslint: 8.57.0
-      tsutils: 3.21.0(typescript@5.4.2)
-    optionalDependencies:
-      typescript: 5.4.2
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  '@typescript-eslint/type-utils@5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2)':
-    dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.4.2)
-      '@typescript-eslint/utils': 5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2)
-      debug: 4.4.1
-      eslint: 9.39.2(jiti@1.21.0)
       tsutils: 3.21.0(typescript@5.4.2)
     optionalDependencies:
       typescript: 5.4.2
@@ -13736,21 +13734,6 @@ snapshots:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.4.2)
       eslint: 8.57.0
-      eslint-scope: 5.1.1
-      semver: 7.6.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  '@typescript-eslint/utils@5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.39.2(jiti@1.21.0))
-      '@types/json-schema': 7.0.15
-      '@types/semver': 7.5.8
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.4.2)
-      eslint: 9.39.2(jiti@1.21.0)
       eslint-scope: 5.1.1
       semver: 7.6.0
     transitivePeerDependencies:
@@ -16442,7 +16425,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.19.1(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.19.1(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-react: 7.34.0(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.57.0)
@@ -16492,23 +16475,23 @@ snapshots:
     dependencies:
       eslint: 8.56.0
 
-  eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.24.1(@babel/core@7.24.0))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.0))(eslint@9.39.2(jiti@1.21.0))(jest@27.5.1)(typescript@5.4.2):
+  eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.24.1(@babel/core@7.24.0))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.0))(eslint@8.57.0)(jest@27.5.1)(typescript@5.4.2):
     dependencies:
       '@babel/core': 7.24.0
-      '@babel/eslint-parser': 7.23.10(@babel/core@7.24.0)(eslint@9.39.2(jiti@1.21.0))
+      '@babel/eslint-parser': 7.23.10(@babel/core@7.24.0)(eslint@8.57.0)
       '@rushstack/eslint-patch': 1.7.2
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2))(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2)
-      '@typescript-eslint/parser': 5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0)(typescript@5.4.2)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.4.2)
       babel-preset-react-app: 10.0.1
       confusing-browser-globals: 1.0.11
-      eslint: 9.39.2(jiti@1.21.0)
-      eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.24.1(@babel/core@7.24.0))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.0))(eslint@9.39.2(jiti@1.21.0))
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2))(eslint@9.39.2(jiti@1.21.0))
-      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2))(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2))(eslint@9.39.2(jiti@1.21.0))(jest@27.5.1)(typescript@5.4.2)
-      eslint-plugin-jsx-a11y: 6.8.0(eslint@9.39.2(jiti@1.21.0))
-      eslint-plugin-react: 7.34.0(eslint@9.39.2(jiti@1.21.0))
-      eslint-plugin-react-hooks: 4.6.0(eslint@9.39.2(jiti@1.21.0))
-      eslint-plugin-testing-library: 5.11.1(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2)
+      eslint: 8.57.0
+      eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.24.1(@babel/core@7.24.0))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0)
+      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0)(jest@27.5.1)(typescript@5.4.2)
+      eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
+      eslint-plugin-react: 7.34.0(eslint@8.57.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.57.0)
+      eslint-plugin-testing-library: 5.11.1(eslint@8.57.0)(typescript@5.4.2)
     optionalDependencies:
       typescript: 5.4.2
     transitivePeerDependencies:
@@ -16533,7 +16516,7 @@ snapshots:
       enhanced-resolve: 5.18.3
       eslint: 8.57.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.19.1(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.19.1(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.3
       is-core-module: 2.13.1
@@ -16544,12 +16527,12 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@1.21.0)):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2)
-      eslint: 9.39.2(jiti@1.21.0)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.4.2)
+      eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
@@ -16587,15 +16570,15 @@ snapshots:
       lodash.memoize: 4.1.2
       semver: 7.6.0
 
-  eslint-plugin-flowtype@8.0.3(@babel/plugin-syntax-flow@7.24.1(@babel/core@7.24.0))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.0))(eslint@9.39.2(jiti@1.21.0)):
+  eslint-plugin-flowtype@8.0.3(@babel/plugin-syntax-flow@7.24.1(@babel/core@7.24.0))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.0))(eslint@8.57.0):
     dependencies:
       '@babel/plugin-syntax-flow': 7.24.1(@babel/core@7.24.0)
       '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.24.0)
-      eslint: 9.39.2(jiti@1.21.0)
+      eslint: 8.57.0
       lodash: 4.17.21
       string-natural-compare: 3.0.1
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2))(eslint@9.39.2(jiti@1.21.0)):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.4
@@ -16603,9 +16586,9 @@ snapshots:
       array.prototype.flatmap: 1.3.2
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.2(jiti@1.21.0)
+      eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@1.21.0))
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -16616,13 +16599,13 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.4.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.19.1(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.4
@@ -16649,12 +16632,12 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2))(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2))(eslint@9.39.2(jiti@1.21.0))(jest@27.5.1)(typescript@5.4.2):
+  eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0)(jest@27.5.1)(typescript@5.4.2):
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2)
-      eslint: 9.39.2(jiti@1.21.0)
+      '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.57.0)(typescript@5.4.2)
+      eslint: 8.57.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2))(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0)(typescript@5.4.2)
       jest: 27.5.1
     transitivePeerDependencies:
       - supports-color
@@ -16700,32 +16683,22 @@ snapshots:
       object.entries: 1.1.7
       object.fromentries: 2.0.7
 
-  eslint-plugin-jsx-a11y@6.8.0(eslint@9.39.2(jiti@1.21.0)):
-    dependencies:
-      '@babel/runtime': 7.24.0
-      aria-query: 5.3.0
-      array-includes: 3.1.7
-      array.prototype.flatmap: 1.3.2
-      ast-types-flow: 0.0.8
-      axe-core: 4.7.0
-      axobject-query: 3.2.1
-      damerau-levenshtein: 1.0.8
-      emoji-regex: 9.2.2
-      es-iterator-helpers: 1.0.17
-      eslint: 9.39.2(jiti@1.21.0)
-      hasown: 2.0.2
-      jsx-ast-utils: 3.3.5
-      language-tags: 1.0.9
-      minimatch: 3.1.2
-      object.entries: 1.1.7
-      object.fromentries: 2.0.7
-
-  eslint-plugin-prettier@5.1.3(@types/eslint@9.6.1)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.56.0)(prettier@3.2.5):
+  eslint-plugin-prettier@5.1.3(@types/eslint@9.6.1)(eslint-config-prettier@9.1.0(eslint@8.56.0))(eslint@8.56.0)(prettier@3.2.5):
     dependencies:
       eslint: 8.56.0
       prettier: 3.2.5
       prettier-linter-helpers: 1.0.0
       synckit: 0.8.8
+    optionalDependencies:
+      '@types/eslint': 9.6.1
+      eslint-config-prettier: 9.1.0(eslint@8.56.0)
+
+  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.2.5):
+    dependencies:
+      eslint: 8.57.0
+      prettier: 3.2.5
+      prettier-linter-helpers: 1.0.1
+      synckit: 0.11.12
     optionalDependencies:
       '@types/eslint': 9.6.1
       eslint-config-prettier: 9.1.0(eslint@8.56.0)
@@ -16797,10 +16770,10 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.10
 
-  eslint-plugin-testing-library@5.11.1(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2):
+  eslint-plugin-testing-library@5.11.1(eslint@8.57.0)(typescript@5.4.2):
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2)
-      eslint: 9.39.2(jiti@1.21.0)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.4.2)
+      eslint: 8.57.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -16831,10 +16804,10 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint-webpack-plugin@3.2.0(eslint@9.39.2(jiti@1.21.0))(webpack@5.90.3):
+  eslint-webpack-plugin@3.2.0(eslint@8.57.0)(webpack@5.90.3):
     dependencies:
       '@types/eslint': 8.56.5
-      eslint: 9.39.2(jiti@1.21.0)
+      eslint: 8.57.0
       jest-worker: 28.1.3
       micromatch: 4.0.5
       normalize-path: 3.0.0
@@ -17381,7 +17354,7 @@ snapshots:
 
   forever-agent@0.6.1: {}
 
-  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2)(webpack@5.90.3):
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@8.57.0)(typescript@5.4.2)(webpack@5.90.3):
     dependencies:
       '@babel/code-frame': 7.24.2
       '@types/json-schema': 7.0.15
@@ -17399,7 +17372,7 @@ snapshots:
       typescript: 5.4.2
       webpack: 5.90.3
     optionalDependencies:
-      eslint: 9.39.2(jiti@1.21.0)
+      eslint: 8.57.0
 
   fork-ts-checker-webpack-plugin@6.5.3(eslint@9.39.2(jiti@1.21.0))(typescript@5.9.3)(webpack@4.47.0):
     dependencies:
@@ -20721,6 +20694,10 @@ snapshots:
     dependencies:
       fast-diff: 1.3.0
 
+  prettier-linter-helpers@1.0.1:
+    dependencies:
+      fast-diff: 1.3.0
+
   prettier@3.2.4: {}
 
   prettier@3.2.5: {}
@@ -20901,7 +20878,7 @@ snapshots:
       regenerator-runtime: 0.13.11
       whatwg-fetch: 3.6.20
 
-  react-dev-utils@12.0.1(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2)(webpack@5.90.3):
+  react-dev-utils@12.0.1(eslint@8.57.0)(typescript@5.4.2)(webpack@5.90.3):
     dependencies:
       '@babel/code-frame': 7.24.2
       address: 1.2.2
@@ -20912,7 +20889,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2)(webpack@5.90.3)
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.57.0)(typescript@5.4.2)(webpack@5.90.3)
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -20972,7 +20949,7 @@ snapshots:
       '@remix-run/router': 1.15.3
       react: 18.2.0
 
-  react-scripts@5.0.1(@babel/plugin-syntax-flow@7.24.1(@babel/core@7.24.0))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.0))(@types/babel__core@7.20.5)(@types/webpack@4.41.38)(eslint@9.39.2(jiti@1.21.0))(react@18.2.0)(type-fest@3.13.1)(typescript@5.4.2):
+  react-scripts@5.0.1(@babel/plugin-syntax-flow@7.24.1(@babel/core@7.24.0))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.0))(@types/babel__core@7.20.5)(@types/webpack@4.41.38)(eslint@8.57.0)(react@18.2.0)(type-fest@3.13.1)(typescript@5.4.2):
     dependencies:
       '@babel/core': 7.24.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(@types/webpack@4.41.38)(react-refresh@0.11.0)(type-fest@3.13.1)(webpack-dev-server@4.15.1(webpack@5.90.3))(webpack@5.90.3)
@@ -20989,9 +20966,9 @@ snapshots:
       css-minimizer-webpack-plugin: 3.4.1(webpack@5.90.3)
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
-      eslint: 9.39.2(jiti@1.21.0)
-      eslint-config-react-app: 7.0.1(@babel/plugin-syntax-flow@7.24.1(@babel/core@7.24.0))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.0))(eslint@9.39.2(jiti@1.21.0))(jest@27.5.1)(typescript@5.4.2)
-      eslint-webpack-plugin: 3.2.0(eslint@9.39.2(jiti@1.21.0))(webpack@5.90.3)
+      eslint: 8.57.0
+      eslint-config-react-app: 7.0.1(@babel/plugin-syntax-flow@7.24.1(@babel/core@7.24.0))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.0))(eslint@8.57.0)(jest@27.5.1)(typescript@5.4.2)
+      eslint-webpack-plugin: 3.2.0(eslint@8.57.0)(webpack@5.90.3)
       file-loader: 6.2.0(webpack@5.90.3)
       fs-extra: 10.1.0
       html-webpack-plugin: 5.6.0(webpack@5.90.3)
@@ -21008,7 +20985,7 @@ snapshots:
       prompts: 2.4.2
       react: 18.2.0
       react-app-polyfill: 3.0.0
-      react-dev-utils: 12.0.1(eslint@9.39.2(jiti@1.21.0))(typescript@5.4.2)(webpack@5.90.3)
+      react-dev-utils: 12.0.1(eslint@8.57.0)(typescript@5.4.2)(webpack@5.90.3)
       react-refresh: 0.11.0
       resolve: 1.22.8
       resolve-url-loader: 4.0.0
@@ -22090,6 +22067,10 @@ snapshots:
       stable: 0.1.8
 
   symbol-tree@3.2.4: {}
+
+  synckit@0.11.12:
+    dependencies:
+      '@pkgr/core': 0.2.9
 
   synckit@0.8.8:
     dependencies:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import licensePlugin from 'vite-plugin-banner'
 import { dependencies, version } from './package.json'
 import banner2 from 'rollup-plugin-banner2'
 
-const licenseContents = `FingerprintJS Pro React v${version} - Copyright (c) FingerprintJS, Inc, ${new Date().getFullYear()} (https://fingerprint.com)
+const licenseContents = `Fingerprint React SDK v${version} - Copyright (c) FingerprintJS, Inc, ${new Date().getFullYear()} (https://fingerprint.com)
 Licensed under the MIT (http://www.opensource.org/licenses/mit-license.php) license.`
 
 export default defineConfig({


### PR DESCRIPTION
- Updates product-facing docs and examples from FingerprintJS Pro/Fingerprint Pro to Fingerprint and Fingerprint React SDK.
- Removes the stale `FingerprintJSPro` import from the README example.
- Adds the missing root `eslint-plugin-prettier` dev dependency so the existing pre-commit lint hook can resolve the preact example config.